### PR TITLE
Support Rollup 3 without npm --legacy-peer-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "javascript-obfuscator": "*",
-    "rollup": "^2.56.3"
+    "rollup": "^2.56.3||^3.0.0"
   },
   "devDependencies": {
     "javascript-obfuscator": "^4.0.0",


### PR DESCRIPTION
Support Rollup 3 without npm --legacy-peer-deps

Otherwise the following the error is reported with any npm operations:

```npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: rollup-plugin-obfuscator@1.0.2
npm ERR! Found: rollup@3.20.2
npm ERR! node_modules/rollup
npm ERR!   peerOptional rollup@"^1.20.0||^2.0.0||^3.0.0" from @rollup/plugin-babel@6.0.3
npm ERR!   node_modules/@rollup/plugin-babel
npm ERR!     dev @rollup/plugin-babel@"^6.0.3" from the root project
npm ERR!   peerOptional rollup@"^2.68.0||^3.0.0" from @rollup/plugin-commonjs@24.0.1
npm ERR!   node_modules/@rollup/plugin-commonjs
npm ERR!     dev @rollup/plugin-commonjs@"^24.0.1" from the root project
npm ERR!   11 more (@rollup/plugin-image, @rollup/plugin-json, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer rollup@"^2.56.3" from rollup-plugin-obfuscator@1.0.2
npm ERR! node_modules/rollup-plugin-obfuscator
npm ERR!   dev rollup-plugin-obfuscator@"^1.0.2" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: rollup@2.79.1
npm ERR! node_modules/rollup
npm ERR!   peer rollup@"^2.56.3" from rollup-plugin-obfuscator@1.0.2
npm ERR!   node_modules/rollup-plugin-obfuscator
npm ERR!     dev rollup-plugin-obfuscator@"^1.0.2" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/zakjan/.npm/eresolve-report.txt for a full report.```