### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepublishOnly": "npm run build"
   },
-  "repository": "git@github.com:getkey/rollup-plugin-obfuscator.git",
+  "repository": "git+https://github.com/getkey/rollup-plugin-obfuscator.git",
   "license": "MPL-2.0",
   "private": false,
   "files": [


### PR DESCRIPTION
## Summary

- normalize the package `repository` metadata from the SSH-style `git@github.com:...` form to `git+https://github.com/getkey/rollup-plugin-obfuscator.git`
- leave runtime code, dependencies, package versioning, and published entry points unchanged

## Validation

- `yarn install --frozen-lockfile --ignore-scripts`
- package metadata assertion for the normalized repository URL
- `npm run build`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
