### PR TITLE
fix: normalize repository URL from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc",
     "prepublishOnly": "npm run build"
   },
-  "repository": "git@github.com:getkey/rollup-plugin-obfuscator.git",
+  "repository": "git+https://github.com/getkey/rollup-plugin-obfuscator.git",
   "license": "MPL-2.0",
   "private": false,
   "files": [


### PR DESCRIPTION
Changes the `repository` field from `git@github.com:` SSH format to `git+https://` HTTPS format for better compatibility with npm metadata consumers and environments without SSH key setup.

Fixes #1834